### PR TITLE
Fix: Update [dependency-groups] to [tool.uv.dependency-groups]Fix: Update [dependency-groups] to [tool.uv.dependency-groups]Update …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ cli = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[dependency-groups]
+[tool.uv.dependency-groups]
 dev = [
     "pre-commit>=4.0.1",
     "pydantic>=2.10.4",


### PR DESCRIPTION
…pyproject.toml

Updated pyproject.toml to use [tool.uv.dependency-groups] instead of [dependency-groups]. This fixes the TOML parse error encountered by uv during CI/CD checks.